### PR TITLE
Fix odm driver configuration sample

### DIFF
--- a/bundles/SyliusResourceBundle/configuration.rst
+++ b/bundles/SyliusResourceBundle/configuration.rst
@@ -26,7 +26,7 @@ In your ``app/config.yml`` (or in an imported configuration file), you need to d
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     repository: Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository
             my_app.document_name:
-                driver: doctrine/odm
+                driver: doctrine/mongodb-odm
                 object_manager: default
                 templates: App:User
                 classes:


### PR DESCRIPTION
DoctrineODM driver is now "doctrine/mongodb-odm" instead of "doctrine/odm". Update the Basic Configuration sample to reflect this change.